### PR TITLE
Feature/to cache pipeline (#110)

### DIFF
--- a/src/backend/BindGroup.cpp
+++ b/src/backend/BindGroup.cpp
@@ -55,6 +55,9 @@ BindGroup::TextureInfo& BindGroup::TextureInfo::operator=(TextureInfo&& rhs)
         rhs.retainTextures();
         releaseTextures();
         textures = rhs.textures;
+        
+        //release the textures before cleaning the vertor
+        rhs.releaseTextures();
         rhs.textures.clear();
     }
     return *this;


### PR DESCRIPTION
* 【BugFix】release the textures before cleaning the vertor

* 【Feature】use releaseTextures() to remove duplicated code and make the code looks clean